### PR TITLE
It cannot build unless specify the version of setuptools

### DIFF
--- a/images/jupyterhub/Dockerfile
+++ b/images/jupyterhub/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
         python3-dev && \
     apt-get autoclean && apt-get clean && apt-get autoremove
 
-RUN python3 -m pip install --upgrade setuptools pip build wheel
+RUN python3 -m pip install --upgrade setuptools==65.4.1 pip build wheel
 
 # freeze version of pip packages from upstream image
 RUN python3 -m pip list --format freeze > /tmp/requirements


### PR DESCRIPTION
Since it now specifies the old JupyterHub 2.3, a build error will occur if setuptools is the latest. If you revert to 65.4.1, you can build it and it will work without any problems.

Since the build error occurs at the same location, the following problem may also be fixed.

https://github.com/NII-cloud-operation/OperationHub/issues/12