### PR TITLE
Add ep_weave for Sidestickies and refactor Solr for NBSearch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "images/nbsearch-solr/nbsearch"]
 	path = images/nbsearch-solr/nbsearch
 	url = https://github.com/NII-cloud-operation/nbsearch.git
+[submodule "images/ep_weave/ep_weave"]
+	path = images/ep_weave/ep_weave
+	url = https://github.com/NII-cloud-operation/ep_weave.git

--- a/config/ep_weave/jupyterhub_config.py
+++ b/config/ep_weave/jupyterhub_config.py
@@ -1,0 +1,35 @@
+import os
+from jupyterhub_oidcp import configure_jupyterhub_oidcp
+
+c.JupyterHub.load_roles = [
+    {
+        'name': 'user',
+        'scopes': ['self', 'access:services'],
+    }
+]
+
+server_name = os.environ['SERVER_NAME']
+
+configure_jupyterhub_oidcp(
+    c,
+    base_url=f"https://{server_name}/",
+    internal_base_url="http://jupyterhub:8000",
+    debug=True,
+    services=[
+        {
+            "oauth_client_id": os.environ['EP_WEAVE_OAUTH_CLIENT_ID'],
+            "api_token": os.environ['EP_WEAVE_OAUTH_CLIENT_SECRET'],
+            "redirect_uris": [f"https://{server_name}/services/ep_weave/ep_openid_connect/callback"],
+        }
+    ],
+    oauth_client_allowed_scopes=None,
+    vault_path="./tmp/jupyterhub_oid/.vault",
+)
+
+c.JupyterHub.services.append(
+    {
+        'name': 'ep_weave',
+        'admin': False,
+        'url': f'http://ep-weave-etherpad-proxy',
+    }
+)

--- a/config/ep_weave/jupyterhub_config.py
+++ b/config/ep_weave/jupyterhub_config.py
@@ -1,31 +1,3 @@
-import os
-from jupyterhub_oidcp import configure_jupyterhub_oidcp
-
-c.JupyterHub.load_roles = [
-    {
-        'name': 'user',
-        'scopes': ['self', 'access:services'],
-    }
-]
-
-server_name = os.environ['SERVER_NAME']
-
-configure_jupyterhub_oidcp(
-    c,
-    base_url=f"https://{server_name}/",
-    internal_base_url="http://jupyterhub:8000",
-    debug=True,
-    services=[
-        {
-            "oauth_client_id": os.environ['EP_WEAVE_OAUTH_CLIENT_ID'],
-            "api_token": os.environ['EP_WEAVE_OAUTH_CLIENT_SECRET'],
-            "redirect_uris": [f"https://{server_name}/services/ep_weave/ep_openid_connect/callback"],
-        }
-    ],
-    oauth_client_allowed_scopes=None,
-    vault_path="./tmp/jupyterhub_oid/.vault",
-)
-
 c.JupyterHub.services.append(
     {
         'name': 'ep_weave',

--- a/config/oidc/jupyterhub_config.py
+++ b/config/oidc/jupyterhub_config.py
@@ -21,13 +21,24 @@ if enable_ep_weave is not None and bool(strtobool(enable_ep_weave)):
         "redirect_uris": [f"https://{server_name}/services/ep_weave/ep_openid_connect/callback"],
     })
 
+enable_nbsearch = os.environ.get('NBSEARCHDB_ENABLE_OIDC_SERVICE', None)
+if enable_nbsearch is not None and bool(strtobool(enable_nbsearch)):
+    oidc_services.append({
+        "oauth_client_id": os.environ['NBSEARCHDB_OAUTH_CLIENT_ID'],
+        "api_token": os.environ['NBSEARCHDB_OAUTH_CLIENT_SECRET'],
+        "redirect_uris": [f"https://{server_name}/services/solr/oauth2/callback"],
+    })
+
 if len(oidc_services) > 0:
     configure_jupyterhub_oidcp(
         c,
+        issuer="http://jupyterhub:8000/services/oidcp/internal/",
         base_url=f"https://{server_name}/",
         internal_base_url="http://jupyterhub:8000",
         debug=True,
         services=oidc_services,
         oauth_client_allowed_scopes=None,
         vault_path="./tmp/jupyterhub_oid/.vault",
+        admin_email_pattern="{uid}@admin.jupyterhub",
+        user_email_pattern="{uid}@user.jupyterhub",
     )

--- a/config/oidc/jupyterhub_config.py
+++ b/config/oidc/jupyterhub_config.py
@@ -1,0 +1,33 @@
+from distutils.util import strtobool
+import os
+
+from jupyterhub_oidcp import configure_jupyterhub_oidcp
+
+c.JupyterHub.load_roles = [
+    {
+        'name': 'user',
+        'scopes': ['self', 'access:services'],
+    }
+]
+
+server_name = os.environ['SERVER_NAME']
+
+oidc_services = []
+enable_ep_weave = os.environ.get('EP_WEAVE_ENABLE_OIDC_SERVICE', None)
+if enable_ep_weave is not None and bool(strtobool(enable_ep_weave)):
+    oidc_services.append({
+        "oauth_client_id": os.environ['EP_WEAVE_OAUTH_CLIENT_ID'],
+        "api_token": os.environ['EP_WEAVE_OAUTH_CLIENT_SECRET'],
+        "redirect_uris": [f"https://{server_name}/services/ep_weave/ep_openid_connect/callback"],
+    })
+
+if len(oidc_services) > 0:
+    configure_jupyterhub_oidcp(
+        c,
+        base_url=f"https://{server_name}/",
+        internal_base_url="http://jupyterhub:8000",
+        debug=True,
+        services=oidc_services,
+        oauth_client_allowed_scopes=None,
+        vault_path="./tmp/jupyterhub_oid/.vault",
+    )

--- a/docker-compose.ep_weave.yml
+++ b/docker-compose.ep_weave.yml
@@ -40,11 +40,13 @@ services:
       DB_USER: etherpaduser
       LOGLEVEL: "debug"
       REQUIRE_AUTHENTICATION: "true"
-      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client}
-      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret}
+      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client_changeme}
+      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret_changeme}
       EP_WEAVE_BASE_URL: "https://${SERVER_NAME}/services/ep_weave/"
+      EP_WEAVE_API_KEY: ${EP_WEAVE_API_KEY:-ep_weave_api_key_changeme}
     volumes:
       - ./images/ep_weave/settings/local.json:/opt/etherpad-lite/settings.json:ro
+    command: /bin/bash -c "echo ${EP_WEAVE_API_KEY:-ep_weave_api_key_changeme} > /opt/etherpad-lite/APIKEY.txt && pnpm run prod --apikey /opt/etherpad-lite/APIKEY.txt"
     depends_on:
       - ep-weave-postgresql
       - ep-weave-solr
@@ -65,20 +67,11 @@ services:
   jupyterhub:
     # Override NBSEARCHDB_* environment variables
     environment:
-    #   NBSEARCHDB_SOLR_BASE_URL: "${NBSEARCHDB_SOLR_BASE_URL:-http://nbsearch-solr:8983}"
-    #   NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME: "${NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME:-}"
-    #   NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD: "${NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD:-}"
-    #   NBSEARCHDB_S3_ENDPOINT_URL: "${NBSEARCHDB_S3_ENDPOINT_URL:-http://nbsearch-minio:9000}"
-    #   NBSEARCHDB_S3_ACCESS_KEY: "${NBSEARCHDB_S3_ACCESS_KEY:-nbsearchak}"
-    #   NBSEARCHDB_S3_SECRET_KEY: "${NBSEARCHDB_S3_SECRET_KEY:-nbsearchsk}"
-    #   NBSEARCHDB_S3_REGION_NAME: "${NBSEARCHDB_S3_REGION_NAME:-}"
-    #   NBSEARCHDB_S3_BUCKET_NAME: "${NBSEARCHDB_S3_BUCKET_NAME:-notebooks}"
-    #   NBSEARCHDB_SOLR_NOTEBOOK: "${NBSEARCHDB_SOLR_NOTEBOOK:-jupyter-notebook}"
-    #   NBSEARCHDB_SOLR_CELL: "${NBSEARCHDB_SOLR_CELL:-jupyter-cell}"
-    #   NBSEARCHDB_MY_SERVER_URL: "${NBSEARCHDB_MY_SERVER_URL:-http://localhost:8888/}"
-    #   NBSEARCHDB_AUTO_UPDATE: "0"
-      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client}
-      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret}
+      SIDESTICKIES_EP_WEAVE_URL: "https://${SERVER_NAME}/services/ep_weave/"
+      SIDESTICKIES_EP_WEAVE_API_KEY: "${EP_WEAVE_API_KEY:-ep_weave_api_key_changeme}"
+      SIDESTICKIES_EP_WEAVE_API_URL: "http://ep-weave-etherpad-proxy/services/ep_weave/"
+      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client_changeme}
+      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret_changeme}
       SERVER_NAME: "${SERVER_NAME}"
     volumes:
       - './config/ep_weave/jupyterhub_config.py:/jupyterhub_config.d/ep_weave.py:ro'

--- a/docker-compose.ep_weave.yml
+++ b/docker-compose.ep_weave.yml
@@ -31,6 +31,8 @@ services:
     build:
       context: ./images/ep_weave/ep_weave
       dockerfile: Dockerfile
+      args:
+        - ETHERPAD_IMAGE_TAG=develop
     environment:
       DB_HOST: ep-weave-postgresql
       DB_NAME: etherpad

--- a/docker-compose.ep_weave.yml
+++ b/docker-compose.ep_weave.yml
@@ -69,6 +69,7 @@ services:
   jupyterhub:
     # Override NBSEARCHDB_* environment variables
     environment:
+      EP_WEAVE_ENABLE_OIDC_SERVICE: "1"
       SIDESTICKIES_EP_WEAVE_URL: "https://${SERVER_NAME}/services/ep_weave/"
       SIDESTICKIES_EP_WEAVE_API_KEY: "${EP_WEAVE_API_KEY:-ep_weave_api_key_changeme}"
       SIDESTICKIES_EP_WEAVE_API_URL: "http://ep-weave-etherpad-proxy/services/ep_weave/"
@@ -76,4 +77,5 @@ services:
       EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret_changeme}
       SERVER_NAME: "${SERVER_NAME}"
     volumes:
+      - './config/oidc/jupyterhub_config.py:/jupyterhub_config.d/oidc.py:ro'
       - './config/ep_weave/jupyterhub_config.py:/jupyterhub_config.d/ep_weave.py:ro'

--- a/docker-compose.ep_weave.yml
+++ b/docker-compose.ep_weave.yml
@@ -1,0 +1,84 @@
+volumes:
+  ep_weave_postgres_data_vol:
+    external: false
+  ep_weave_solr_data_vol:
+    external: false
+
+services:
+  ep-weave-solr:
+    build:
+      context: ./images/ep_weave/ep_weave
+      dockerfile: solr/Dockerfile
+    volumes:
+      - ep_weave_solr_data_vol:/var/solr/
+    restart: always
+    networks:
+      - backend
+
+  ep-weave-postgresql:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: etherpad
+      POSTGRES_USER: etherpaduser
+      POSTGRES_PASSWORD: etherpadpass
+    volumes:
+      - ep_weave_postgres_data_vol:/var/lib/postgresql/data/
+    restart: always
+    networks:
+      - backend
+
+  ep-weave-etherpad:
+    build:
+      context: ./images/ep_weave/ep_weave
+      dockerfile: Dockerfile
+    environment:
+      DB_HOST: ep-weave-postgresql
+      DB_NAME: etherpad
+      DB_PASS: etherpadpass
+      DB_PORT: 5432
+      DB_TYPE: postgres
+      DB_USER: etherpaduser
+      LOGLEVEL: "debug"
+      REQUIRE_AUTHENTICATION: "true"
+      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client}
+      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret}
+      EP_WEAVE_BASE_URL: "https://${SERVER_NAME}/services/ep_weave/"
+    volumes:
+      - ./images/ep_weave/settings/local.json:/opt/etherpad-lite/settings.json:ro
+    depends_on:
+      - ep-weave-postgresql
+      - ep-weave-solr
+      - jupyterhub
+    restart: always
+    networks:
+      - backend
+
+  ep-weave-etherpad-proxy:
+    build:
+      context: ./images/ep_weave-etherpad-proxy
+    depends_on:
+      - ep-weave-etherpad
+    restart: always
+    networks:
+      - backend
+
+  jupyterhub:
+    # Override NBSEARCHDB_* environment variables
+    environment:
+    #   NBSEARCHDB_SOLR_BASE_URL: "${NBSEARCHDB_SOLR_BASE_URL:-http://nbsearch-solr:8983}"
+    #   NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME: "${NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME:-}"
+    #   NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD: "${NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD:-}"
+    #   NBSEARCHDB_S3_ENDPOINT_URL: "${NBSEARCHDB_S3_ENDPOINT_URL:-http://nbsearch-minio:9000}"
+    #   NBSEARCHDB_S3_ACCESS_KEY: "${NBSEARCHDB_S3_ACCESS_KEY:-nbsearchak}"
+    #   NBSEARCHDB_S3_SECRET_KEY: "${NBSEARCHDB_S3_SECRET_KEY:-nbsearchsk}"
+    #   NBSEARCHDB_S3_REGION_NAME: "${NBSEARCHDB_S3_REGION_NAME:-}"
+    #   NBSEARCHDB_S3_BUCKET_NAME: "${NBSEARCHDB_S3_BUCKET_NAME:-notebooks}"
+    #   NBSEARCHDB_SOLR_NOTEBOOK: "${NBSEARCHDB_SOLR_NOTEBOOK:-jupyter-notebook}"
+    #   NBSEARCHDB_SOLR_CELL: "${NBSEARCHDB_SOLR_CELL:-jupyter-cell}"
+    #   NBSEARCHDB_MY_SERVER_URL: "${NBSEARCHDB_MY_SERVER_URL:-http://localhost:8888/}"
+    #   NBSEARCHDB_AUTO_UPDATE: "0"
+      EP_WEAVE_OAUTH_CLIENT_ID: ${EP_WEAVE_OAUTH_CLIENT_ID:-ep_weave_oauth_client}
+      EP_WEAVE_OAUTH_CLIENT_SECRET: ${EP_WEAVE_OAUTH_CLIENT_SECRET:-ep_weave_oauth_secret}
+      SERVER_NAME: "${SERVER_NAME}"
+    volumes:
+      - './config/ep_weave/jupyterhub_config.py:/jupyterhub_config.d/ep_weave.py:ro'

--- a/docker-compose.nbsearch.yml
+++ b/docker-compose.nbsearch.yml
@@ -14,12 +14,34 @@ services:
     networks:
       - backend
 
-  nbsearch-solr-proxy:
+  nbsearch-solr-base-proxy:
     build:
       context: ./images/nbsearch-solr-proxy
     depends_on:
       - nbsearch-solr
     restart: always
+    networks:
+      - backend
+
+  nbsearch-solr-proxy:
+    image: bitnami/oauth2-proxy:7
+    depends_on:
+      - jupyterhub
+      - nbsearch-solr-base-proxy
+    restart: always
+    command:
+      - --http-address=0.0.0.0:80
+      - --proxy-prefix=/services/solr/oauth2
+      - --upstream=http://nbsearch-solr-base-proxy:80/
+      - --provider=oidc
+      - --provider-display-name=JupyterHub
+      - --client-id=${NBSEARCHDB_OAUTH_CLIENT_ID:-nbsearchdb_oauth_client_changeme}
+      - --client-secret=${NBSEARCHDB_OAUTH_CLIENT_SECRET:-nbsearchdb_oauth_secret_changeme}
+      - --cookie-secret=${NBSEARCHDB_COOKIE_SECRET:-nbsearchdb_cookiesecret_changeme}
+      - --redirect-url=https://${SERVER_NAME}/services/solr/oauth2/callback
+      - --oidc-issuer-url=http://jupyterhub:8000/services/oidcp/internal/
+      - --email-domain=admin.jupyterhub
+      - --skip-provider-button=true
     networks:
       - backend
 
@@ -67,6 +89,7 @@ services:
   jupyterhub:
     # Override NBSEARCHDB_* environment variables
     environment:
+      NBSEARCHDB_ENABLE_OIDC_SERVICE: "1"
       NBSEARCHDB_SOLR_BASE_URL: "${NBSEARCHDB_SOLR_BASE_URL:-http://nbsearch-solr:8983}"
       NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME: "${NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME:-}"
       NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD: "${NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD:-}"
@@ -79,5 +102,8 @@ services:
       NBSEARCHDB_SOLR_CELL: "${NBSEARCHDB_SOLR_CELL:-jupyter-cell}"
       NBSEARCHDB_MY_SERVER_URL: "${NBSEARCHDB_MY_SERVER_URL:-http://localhost:8888/}"
       NBSEARCHDB_AUTO_UPDATE: "0"
+      NBSEARCHDB_OAUTH_CLIENT_ID: "${NBSEARCHDB_OAUTH_CLIENT_ID:-nbsearchdb_oauth_client_changeme}"
+      NBSEARCHDB_OAUTH_CLIENT_SECRET: "${NBSEARCHDB_OAUTH_CLIENT_SECRET:-nbsearchdb_oauth_secret_changeme}"
     volumes:
+      - './config/oidc/jupyterhub_config.py:/jupyterhub_config.d/oidc.py:ro'
       - './config/nbsearch/jupyterhub_config.py:/jupyterhub_config.d/solr.py:ro'

--- a/images/ep_weave-etherpad-proxy/Dockerfile
+++ b/images/ep_weave-etherpad-proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:stable
+
+COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/images/ep_weave-etherpad-proxy/nginx.conf
+++ b/images/ep_weave-etherpad-proxy/nginx.conf
@@ -1,0 +1,32 @@
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+
+    client_max_body_size 50M;
+
+    server {
+        listen       80;
+
+        location /services/ep_weave/ {
+            proxy_pass         http://ep-weave-etherpad:9001/;
+            proxy_buffering    off;
+            proxy_set_header   Host $host;
+            proxy_pass_header  Server;
+
+            # Enabling WebSocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+
+            # Adjust timeout for WebSocket
+            proxy_read_timeout 60s;
+            proxy_send_timeout 60s;
+
+            proxy_set_header    X-Real-IP $remote_addr; # https://nginx.org/en/docs/http/ngx_http_proxy_module.html
+            proxy_set_header    X-Forwarded-For $remote_addr;
+            proxy_set_header    X-Forwarded-Proto https;
+        }
+    }
+}

--- a/images/ep_weave/settings/local.json
+++ b/images/ep_weave/settings/local.json
@@ -1,0 +1,666 @@
+/**
+ * THIS IS THE SETTINGS FILE THAT IS COPIED INSIDE THE DOCKER CONTAINER.
+ *
+ * By default, some runtime customizations are supported (see the
+ * documentation).
+ *
+ * If you need more control, edit this file and rebuild the container.
+ */
+
+/*
+ * This file must be valid JSON. But comments are allowed
+ *
+ * Please edit settings.json, not settings.json.template
+ *
+ * Please note that starting from Etherpad 1.6.0 you can store DB credentials in
+ * a separate file (credentials.json).
+ *
+ *
+ * ENVIRONMENT VARIABLE SUBSTITUTION
+ * =================================
+ *
+ * All the configuration values can be read from environment variables using the
+ * syntax "${ENV_VAR}" or "${ENV_VAR:default_value}".
+ *
+ * This is useful, for example, when running in a Docker container.
+ *
+ * DETAILED RULES:
+ *   - If the environment variable is set to the string "true" or "false", the
+ *     value becomes Boolean true or false.
+ *   - If the environment variable is set to the string "null", the value
+ *     becomes null.
+ *   - If the environment variable is set to the string "undefined", the setting
+ *     is removed entirely, except when used as the member of an array in which
+ *     case it becomes null.
+ *   - If the environment variable is set to a string representation of a finite
+ *     number, the string is converted to that number.
+ *   - If the environment variable is set to any other string, including the
+ *     empty string, the value is that string.
+ *   - If the environment variable is unset and a default value is provided, the
+ *     value is as if the environment variable was set to the provided default:
+ *       - "${UNSET_VAR:}" becomes the empty string.
+ *       - "${UNSET_VAR:foo}" becomes the string "foo".
+ *       - "${UNSET_VAR:true}" and "${UNSET_VAR:false}" become true and false.
+ *       - "${UNSET_VAR:null}" becomes null.
+ *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
+ *         to null, if used as a member of an array).
+ *   - If the environment variable is unset and no default value is provided,
+ *     the value becomes null. THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF
+ *     ETHERPAD; if you want the default value to be null, you should explicitly
+ *     specify "null" as the default value.
+ *
+ * EXAMPLE:
+ *    "port":     "${PORT:9001}"
+ *    "minify":   "${MINIFY}"
+ *    "skinName": "${SKIN_NAME:colibris}"
+ *
+ * Would read the configuration values for those items from the environment
+ * variables PORT, MINIFY and SKIN_NAME.
+ *
+ * If PORT and SKIN_NAME variables were not defined, the default values 9001 and
+ * "colibris" would be used.
+ * The configuration value "minify", on the other hand, does not have a
+ * designated default value. Thus, if the environment variable MINIFY were
+ * undefined, "minify" would be null.
+ *
+ * REMARKS:
+ * 1) please note that variable substitution always needs to be quoted.
+ *
+ *    "port":     9001,            <-- Literal values. When not using
+ *    "minify":   false                substitution, only strings must be
+ *    "skinName": "colibris"           quoted. Booleans and numbers must not.
+ *
+ *    "port":     "${PORT:9001}"   <-- CORRECT: if you want to use a variable
+ *    "minify":   "${MINIFY:true}"     substitution, put quotes around its name,
+ *    "skinName": "${SKIN_NAME}"       even if the required value is a number or
+ *                                     a boolean.
+ *                                     Etherpad will take care of rewriting it
+ *                                     to the proper type if necessary.
+ *
+ *    "port":     ${PORT:9001}     <-- ERROR: this is not valid json. Quotes
+ *    "minify":   ${MINIFY}            around variable names are missing.
+ *    "skinName": ${SKIN_NAME}
+ *
+ * 2) Beware of undefined variables and default values: nulls and empty strings
+ *    are different!
+ *
+ *    This is particularly important for user's passwords (see the relevant
+ *    section):
+ *
+ *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
+ *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
+ *
+ *    If you want to use an empty value (null) as default value for a variable,
+ *    simply do not set it, without putting any colons: "${ABIWORD}".
+ *
+ * 3) if you want to use newlines in the default value of a string parameter,
+ *    use "\n" as usual.
+ *
+ *    "defaultPadText" : "${DEFAULT_PAD_TEXT}Line 1\nLine 2"
+ */
+ {
+  /*
+   * Name your instance!
+   */
+  "title": "${TITLE:EP\ud83e\uddf6\ud83e\udea1}", /* Ball of Yarn and Sewing needle */
+
+  /*
+   * Pathname of the favicon you want to use. If null, the skin's favicon is
+   * used if one is provided by the skin, otherwise the default Etherpad favicon
+   * is used. If this is a relative path it is interpreted as relative to the
+   * Etherpad root directory.
+   */
+  "favicon": "${FAVICON:null}",
+
+  /*
+   * Skin name.
+   *
+   * Its value has to be an existing directory under src/static/skins.
+   * You can write your own, or use one of the included ones:
+   *
+   * - "no-skin":  an empty skin (default). This yields the unmodified,
+   *               traditional Etherpad theme.
+   * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
+   *               become the default in Etherpad 2.0
+   */
+  "skinName": "${SKIN_NAME:colibris}",
+
+  /*
+   * Skin Variants
+   *
+   * Use the UI skin variants builder at /p/test#skinvariantsbuilder
+   *
+   * For the colibris skin only, you can choose how to render the three main
+   * containers:
+   * - toolbar (top menu with icons)
+   * - editor (containing the text of the pad)
+   * - background (area outside of editor, mostly visible when using page style)
+   *
+   * For each of the 3 containers you can choose 4 color combinations:
+   * super-light, light, dark, super-dark.
+   *
+   * For example, to make the toolbar dark, you will include "dark-toolbar" into
+   * skinVariants.
+   *
+   * You can provide multiple skin variants separated by spaces. Default
+   * skinVariant is "super-light-toolbar super-light-editor light-background".
+   *
+   * For the editor container, you can also make it full width by adding
+   * "full-width-editor" variant (by default editor is rendered as a page, with
+   * a max-width of 900px).
+   */
+  "skinVariants": "${SKIN_VARIANTS:super-light-toolbar super-light-editor light-background}",
+
+  /*
+   * IP and port which Etherpad should bind at.
+   *
+   * Binding to a Unix socket is also supported: just use an empty string for
+   * the ip, and put the full path to the socket in the port parameter.
+   *
+   * EXAMPLE USING UNIX SOCKET:
+   *    "ip": "",                             // <-- has to be an empty string
+   *    "port" : "/somepath/etherpad.socket", // <-- path to a Unix socket
+   */
+  "ip": "${IP:0.0.0.0}",
+  "port": "${PORT:9001}",
+
+  /*
+   * Option to hide/show the settings.json in admin page.
+   *
+   * Default option is set to true
+   */
+  "showSettingsInAdminPage": "${SHOW_SETTINGS_IN_ADMIN_PAGE:true}",
+
+  /*
+   * Node native SSL support
+   *
+   * This is disabled by default.
+   * Make sure to have the minimum and correct file access permissions set so
+   * that the Etherpad server can access them
+   */
+
+  /*
+  "ssl" : {
+            "key"  : "/path-to-your/epl-server.key",
+            "cert" : "/path-to-your/epl-server.crt",
+            "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
+          },
+  */
+
+  /*
+   * The type of the database.
+   *
+   * You can choose between many DB drivers, for example: dirty, postgres,
+   * sqlite, mysql.
+   *
+   * You shouldn't use "dirty" for for anything else than testing or
+   * development.
+   *
+   *
+   * Database specific settings are dependent on dbType, and go in dbSettings.
+   * Remember that since Etherpad 1.6.0 you can also store this information in
+   * credentials.json.
+   *
+   * For a complete list of the supported drivers, please refer to:
+   * https://www.npmjs.com/package/ueberdb2
+   */
+
+  "dbType": "${DB_TYPE:dirty}",
+  "dbSettings": {
+    "host":       "${DB_HOST:undefined}",
+    "port":       "${DB_PORT:undefined}",
+    "database":   "${DB_NAME:undefined}",
+    "user":       "${DB_USER:undefined}",
+    "password":   "${DB_PASS:undefined}",
+    "charset":    "${DB_CHARSET:undefined}",
+    "filename":   "${DB_FILENAME:var/dirty.db}",
+    "collection": "${DB_COLLECTION:undefined}",
+    "url":        "${DB_URL:undefined}"
+  },
+
+  /*
+   * The default text of a pad
+   */
+  "defaultPadText" : "${DEFAULT_PAD_TEXT:Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at https:\/\/etherpad.org\n}",
+
+  /*
+   * Default Pad behavior.
+   *
+   * Change them if you want to override.
+   */
+  "padOptions": {
+    "noColors":         "${PAD_OPTIONS_NO_COLORS:false}",
+    "showControls":     "${PAD_OPTIONS_SHOW_CONTROLS:true}",
+    "showChat":         "${PAD_OPTIONS_SHOW_CHAT:true}",
+    "showLineNumbers":  "${PAD_OPTIONS_SHOW_LINE_NUMBERS:true}",
+    "useMonospaceFont": "${PAD_OPTIONS_USE_MONOSPACE_FONT:false}",
+    "userName":         "${PAD_OPTIONS_USER_NAME:null}",
+    "userColor":        "${PAD_OPTIONS_USER_COLOR:null}",
+    "rtl":              "${PAD_OPTIONS_RTL:false}",
+    "alwaysShowChat":   "${PAD_OPTIONS_ALWAYS_SHOW_CHAT:false}",
+    "chatAndUsers":     "${PAD_OPTIONS_CHAT_AND_USERS:false}",
+    "lang":             "${PAD_OPTIONS_LANG:null}"
+  },
+
+  /*
+   * Pad Shortcut Keys
+   */
+  "padShortcutEnabled" : {
+    "altF9":     "${PAD_SHORTCUTS_ENABLED_ALT_F9:true}",      /* focus on the File Menu and/or editbar */
+    "altC":      "${PAD_SHORTCUTS_ENABLED_ALT_C:true}",       /* focus on the Chat window */
+    "cmdShift2": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_2:true}", /* shows a gritter popup showing a line author */
+    "delete":    "${PAD_SHORTCUTS_ENABLED_DELETE:true}",
+    "return":    "${PAD_SHORTCUTS_ENABLED_RETURN:true}",
+    "esc":       "${PAD_SHORTCUTS_ENABLED_ESC:true}",         /* in mozilla versions 14-19 avoid reconnecting pad */
+    "cmdS":      "${PAD_SHORTCUTS_ENABLED_CMD_S:true}",       /* save a revision */
+    "tab":       "${PAD_SHORTCUTS_ENABLED_TAB:true}",         /* indent */
+    "cmdZ":      "${PAD_SHORTCUTS_ENABLED_CMD_Z:true}",       /* undo/redo */
+    "cmdY":      "${PAD_SHORTCUTS_ENABLED_CMD_Y:true}",       /* redo */
+    "cmdI":      "${PAD_SHORTCUTS_ENABLED_CMD_I:true}",       /* italic */
+    "cmdB":      "${PAD_SHORTCUTS_ENABLED_CMD_B:true}",       /* bold */
+    "cmdU":      "${PAD_SHORTCUTS_ENABLED_CMD_U:true}",       /* underline */
+    "cmd5":      "${PAD_SHORTCUTS_ENABLED_CMD_5:true}",       /* strike through */
+    "cmdShiftL": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_L:true}", /* unordered list */
+    "cmdShiftN": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_N:true}", /* ordered list */
+    "cmdShift1": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_1:true}", /* ordered list */
+    "cmdH":      "${PAD_SHORTCUTS_ENABLED_CMD_H:true}",       /* backspace */
+    "ctrlHome":  "${PAD_SHORTCUTS_ENABLED_CTRL_HOME:true}",   /* scroll to top of pad */
+    "pageUp":    "${PAD_SHORTCUTS_ENABLED_PAGE_UP:true}",
+    "pageDown":  "${PAD_SHORTCUTS_ENABLED_PAGE_DOWN:true}"
+  },
+
+  /*
+   * Should we suppress errors from being visible in the default Pad Text?
+   */
+  "suppressErrorsInPadText": "${SUPPRESS_ERRORS_IN_PAD_TEXT:false}",
+
+  /*
+   * If this option is enabled, a user must have a session to access pads.
+   * This effectively allows only group pads to be accessed.
+   */
+  "requireSession": "${REQUIRE_SESSION:false}",
+
+  /*
+   * Users may edit pads but not create new ones.
+   *
+   * Pad creation is only via the API.
+   * This applies both to group pads and regular pads.
+   *
+   * ep_weave does not allow new Pad creation by `/p/xxxx` URL.
+   */
+  "editOnly": "true",
+
+  /*
+   * If true, all css & js will be minified before sending to the client.
+   *
+   * This will improve the loading performance massively, but makes it difficult
+   * to debug the javascript/css
+   */
+  "minify": "${MINIFY:true}",
+
+  /*
+   * How long may clients use served javascript code (in seconds)?
+   *
+   * Not setting this may cause problems during deployment.
+   * Set to 0 to disable caching.
+   */
+  "maxAge": "${MAX_AGE:21600}", // 60 * 60 * 6 = 6 hours
+
+  /*
+   * Absolute path to the Abiword executable.
+   *
+   * Abiword is needed to get advanced import/export features of pads. Setting
+   * it to null disables Abiword and will only allow plain text and HTML
+   * import/exports.
+   */
+  "abiword": "${ABIWORD:null}",
+
+  /*
+   * This is the absolute path to the soffice executable.
+   *
+   * LibreOffice can be used in lieu of Abiword to export pads.
+   * Setting it to null disables LibreOffice exporting.
+   */
+  "soffice": "${SOFFICE:null}",
+
+  /*
+   * Allow import of file types other than the supported ones:
+   * txt, doc, docx, rtf, odt, html & htm
+   */
+  "allowUnknownFileEnds": "${ALLOW_UNKNOWN_FILE_ENDS:true}",
+
+  /*
+   * This setting is used if you require authentication of all users.
+   *
+   * Note: "/admin" always requires authentication.
+   */
+  "requireAuthentication": "${REQUIRE_AUTHENTICATION:false}",
+
+  /*
+   * Require authorization by a module, or a user with is_admin set, see below.
+   */
+  "requireAuthorization": "${REQUIRE_AUTHORIZATION:false}",
+
+  /*
+   * When you use NGINX or another proxy/load-balancer set this to true.
+   *
+   * This is especially necessary when the reverse proxy performs SSL
+   * termination, otherwise the cookies will not have the "secure" flag.
+   *
+   * The other effect will be that the logs will contain the real client's IP,
+   * instead of the reverse proxy's IP.
+   */
+  "trustProxy": "${TRUST_PROXY:false}",
+
+  /*
+   * Settings controlling the session cookie issued by Etherpad.
+   */
+  "cookie": {
+    /*
+     * How often (in milliseconds) the key used to sign the express_sid cookie
+     * should be rotated. Long rotation intervals reduce signature verification
+     * overhead (because there are fewer historical keys to check) and database
+     * load (fewer historical keys to store, and less frequent queries to
+     * get/update the keys). Short rotation intervals are slightly more secure.
+     *
+     * Multiple Etherpad processes sharing the same database (table) is
+     * supported as long as the clock sync error is significantly less than this
+     * value.
+     *
+     * Key rotation can be disabled (not recommended) by setting this to 0 or
+     * null, or by disabling session expiration (see sessionLifetime).
+     */
+    // 86400000 = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+    "keyRotationInterval": "${COOKIE_KEY_ROTATION_INTERVAL:86400000}",
+
+    /*
+     * Value of the SameSite cookie property. "Lax" is recommended unless
+     * Etherpad will be embedded in an iframe from another site, in which case
+     * this must be set to "None". Note: "None" will not work (the browser will
+     * not send the cookie to Etherpad) unless https is used to access Etherpad
+     * (either directly or via a reverse proxy with "trustProxy" set to true).
+     *
+     * "Strict" is not recommended because it has few security benefits but
+     * significant usability drawbacks vs. "Lax". See
+     * https://stackoverflow.com/q/41841880 for discussion.
+     */
+    "sameSite": "${COOKIE_SAME_SITE:Lax}",
+
+    /*
+     * How long (in milliseconds) after navigating away from Etherpad before the
+     * user is required to log in again. (The express_sid cookie is set to
+     * expire at time now + sessionLifetime when first created, and its
+     * expiration time is periodically refreshed to a new now + sessionLifetime
+     * value.) If requireAuthentication is false then this value does not really
+     * matter.
+     *
+     * The "best" value depends on your users' usage patterns and the amount of
+     * convenience you desire. A long lifetime is more convenient (users won't
+     * have to log back in as often) but has some drawbacks:
+     *   - It increases the amount of state kept in the database.
+     *   - It might weaken security somewhat: The cookie expiration is refreshed
+     *     indefinitely without consulting authentication or authorization
+     *     hooks, so once a user has accessed a pad, the user can continue to
+     *     use the pad until the user leaves for longer than sessionLifetime.
+     *   - More historical keys (sessionLifetime / keyRotationInterval) must be
+     *     checked when verifying signatures.
+     *
+     * Session lifetime can be set to infinity (not recommended) by setting this
+     * to null or 0. Note that if the session does not expire, most browsers
+     * will delete the cookie when the browser exits, but a session record is
+     * kept in the database forever.
+     */
+    // 864000000 = 10d * 24h/d * 60m/h * 60s/m * 1000ms/s
+    "sessionLifetime": "${COOKIE_SESSION_LIFETIME:864000000}",
+
+    /*
+     * How long (in milliseconds) before the expiration time of an active user's
+     * session is refreshed (to now + sessionLifetime). This setting affects the
+     * following:
+     *   - How often a new session expiration time will be written to the
+     *     database.
+     *   - How often each user's browser will ping the Etherpad server to
+     *     refresh the expiration time of the session cookie.
+     *
+     * High values reduce the load on the database and the load from browsers,
+     * but can shorten the effective session lifetime if Etherpad is restarted
+     * or the user navigates away.
+     *
+     * Automatic session refreshes can be disabled (not recommended) by setting
+     * this to null.
+     */
+    // 86400000 = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+    "sessionRefreshInterval": "${COOKIE_SESSION_REFRESH_INTERVAL:86400000}"
+  },
+
+  /*
+   * Privacy: disable IP logging
+   */
+  "disableIPlogging": "${DISABLE_IP_LOGGING:false}",
+
+  /*
+   * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
+   * message is shown to user.
+   *
+   * Set to 0 to disable automatic reconnection.
+   */
+  "automaticReconnectionTimeout": "${AUTOMATIC_RECONNECTION_TIMEOUT:0}",
+
+  /*
+   * By default, when caret is moved out of viewport, it scrolls the minimum
+   * height needed to make this line visible.
+   */
+  "scrollWhenFocusLineIsOutOfViewport": {
+
+    /*
+     * Percentage of viewport height to be additionally scrolled.
+     *
+     * E.g.: use "percentage.editionAboveViewport": 0.5, to place caret line in
+     *       the middle of viewport, when user edits a line above of the
+     *       viewport
+     *
+     * Set to 0 to disable extra scrolling
+     */
+    "percentage": {
+      "editionAboveViewport": "${FOCUS_LINE_PERCENTAGE_ABOVE:0}",
+      "editionBelowViewport": "${FOCUS_LINE_PERCENTAGE_BELOW:0}"
+    },
+
+    /*
+     * Time (in milliseconds) used to animate the scroll transition.
+     * Set to 0 to disable animation
+     */
+    "duration": "${FOCUS_LINE_DURATION:0}",
+
+    /*
+     * Flag to control if it should scroll when user places the caret in the
+     * last line of the viewport
+     */
+    "scrollWhenCaretIsInTheLastLineOfViewport": "${FOCUS_LINE_CARET_SCROLL:false}",
+
+    /*
+     * Percentage of viewport height to be additionally scrolled when user
+     * presses arrow up in the line of the top of the viewport.
+     *
+     * Set to 0 to let the scroll to be handled as default by Etherpad
+     */
+    "percentageToScrollWhenUserPressesArrowUp": "${FOCUS_LINE_PERCENTAGE_ARROW_UP:0}"
+  },
+
+  /*
+   * User accounts. These accounts are used by:
+   *   - default HTTP basic authentication if no plugin handles authentication
+   *   - some but not all authentication plugins
+   *   - some but not all authorization plugins
+   *
+   * User properties:
+   *   - password: The user's password. Some authentication plugins will ignore
+   *     this.
+   *   - is_admin: true gives access to /admin. Defaults to false. If you do not
+   *     uncomment this, /admin will not be available!
+   *   - readOnly: If true, this user will not be able to create new pads or
+   *     modify existing pads. Defaults to false.
+   *   - canCreate: If this is true and readOnly is false, this user can create
+   *     new pads. Defaults to true.
+   *
+   * Authentication and authorization plugins may define additional properties.
+   *
+   * WARNING: passwords should not be stored in plaintext in this file.
+   *          If you want to mitigate this, please install ep_hash_auth and
+   *          follow the section "secure your installation" in README.md
+   */
+
+  "users": {
+    "admin": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "${ADMIN_PASSWORD:null}",
+      "is_admin": true
+    },
+    "user": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "${USER_PASSWORD:null}",
+      "is_admin": false
+    }
+  },
+
+  /*
+   * Restrict socket.io transport methods
+   */
+  "socketTransportProtocols" : ["websocket", "polling"],
+
+  "socketIo": {
+    /*
+     * Maximum permitted client message size (in bytes). All messages from
+     * clients that are larger than this will be rejected. Large values make it
+     * possible to paste large amounts of text, and plugins may require a larger
+     * value to work properly, but increasing the value increases susceptibility
+     * to denial of service attacks (malicious clients can exhaust memory).
+     */
+    "maxHttpBufferSize": "${SOCKETIO_MAX_HTTP_BUFFER_SIZE:10000}"
+  },
+
+  /*
+   * Allow Load Testing tools to hit the Etherpad Instance.
+   *
+   * WARNING: this will disable security on the instance.
+   */
+  "loadTest": "${LOAD_TEST:false}",
+
+  /**
+  * Disable dump of objects preventing a clean exit
+  */
+  "dumpOnUncleanExit": "${DUMP_ON_UNCLEAN_EXIT:false}",
+
+  /*
+   * Disable indentation on new line when previous line ends with some special
+   * chars (':', '[', '(', '{')
+   */
+
+  /*
+  "indentationOnNewLine": false,
+  */
+
+  /*
+   * From Etherpad 1.8.3 onwards, import and export of pads is always rate
+   * limited.
+   *
+   * The default is to allow at most 10 requests per IP in a 90 seconds window.
+   * After that the import/export request is rejected.
+   *
+   * See https://github.com/nfriedly/express-rate-limit for more options
+   */
+  "importExportRateLimiting": {
+    // duration of the rate limit window (milliseconds)
+    "windowMs": "${IMPORT_EXPORT_RATE_LIMIT_WINDOW:90000}",
+
+    // maximum number of requests per IP to allow during the rate limit window
+    "max": "${IMPORT_EXPORT_MAX_REQ_PER_IP:10}"
+  },
+
+  /*
+   * From Etherpad 1.8.3 onwards, the maximum allowed size for a single imported
+   * file is always bounded.
+   *
+   * File size is specified in bytes. Default is 50 MB.
+   */
+  "importMaxFileSize": "${IMPORT_MAX_FILE_SIZE:52428800}", // 50 * 1024 * 1024
+
+  /*
+   * From Etherpad 1.8.5 onwards, when Etherpad is in production mode commits from individual users are rate limited
+   *
+   * The default is to allow at most 10 changes per IP in a 1 second window.
+   * After that the change is rejected.
+   *
+   * See https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding for more options
+   */
+  "commitRateLimiting": {
+    // duration of the rate limit window (seconds)
+    "duration": "${COMMIT_RATE_LIMIT_DURATION:1}",
+
+    // maximum number of changes per IP to allow during the rate limit window
+    "points": "${COMMIT_RATE_LIMIT_POINTS:10}"
+  },
+
+  /*
+   * Toolbar buttons configuration.
+   */
+  "toolbar": {
+    "left": [
+      ["bold", "italic", "underline", "strikethrough"],
+      ["orderedlist", "unorderedlist", "indent", "outdent"],
+      ["undo", "redo"]
+    ],
+    "right": [
+      ["importexport", "timeslider", "savedrevision"],
+      ["settings", "embed"],
+      ["showusers"]
+    ],
+    "timeslider": [
+      ["timeslider_export", "timeslider_settings", "timeslider_returnToPad"]
+    ]
+  },
+
+  /*
+   * Expose Etherpad version in the web interface and in the Server http header.
+   *
+   * Do not enable on production machines.
+   */
+  "exposeVersion": "${EXPOSE_VERSION:false}",
+
+  /*
+   * The log level we are using.
+   *
+   * Valid values: DEBUG, INFO, WARN, ERROR
+   */
+  "loglevel": "${LOGLEVEL:INFO}",
+
+  /* Override any strings found in locale directories */
+  "customLocaleStrings": {},
+
+  /* Disable Admin UI tests */
+  "enableAdminUITests": false,
+
+  /*
+   * Enable/Disable case-insensitive pad names.
+   */
+  "lowerCasePadIds": "${LOWER_CASE_PAD_IDS:false}",
+
+  "ep_search": {
+    "type": "solr",
+    "host": "ep-weave-solr",
+    "port": "8983",
+    "core": "pad",
+    "padSerializer": "ep_weave/lib/serializer"
+  },
+  "ep_openid_connect": {
+    "issuer":"http://jupyterhub:8000/services/oidcp/internal/",
+    "client_id": "${EP_WEAVE_OAUTH_CLIENT_ID}",
+    "client_secret": "${EP_WEAVE_OAUTH_CLIENT_SECRET}",
+    "base_url": "${EP_WEAVE_BASE_URL}"
+  },
+  "ep_weave": {
+    "basePath": "/services/ep_weave"
+  }
+}

--- a/images/jupyterhub/Dockerfile
+++ b/images/jupyterhub/Dockerfile
@@ -31,7 +31,7 @@ RUN python3 -m pip wheel --wheel-dir wheelhouse --constraint requirements \
 
 # jupyterhub-oidc-provider
 RUN python3 -m pip wheel --wheel-dir wheelhouse --constraint requirements \
-    git+https://github.com/yacchin1205/jupyterhub-oidc-provider.git@fix/flake8
+    git+https://github.com/NII-cloud-operation/jupyterhub-oidc-provider.git
 
 FROM jupyterhub/jupyterhub:2.3
 

--- a/images/jupyterhub/Dockerfile
+++ b/images/jupyterhub/Dockerfile
@@ -29,6 +29,10 @@ RUN python3 -m pip wheel --wheel-dir wheelhouse --constraint requirements \
     /tmp/authenticator && \
     rm -rf /tmp/authenticator
 
+# jupyterhub-oidc-provider
+RUN python3 -m pip wheel --wheel-dir wheelhouse --constraint requirements \
+    git+https://github.com/yacchin1205/jupyterhub-oidc-provider.git@fix/flake8
+
 FROM jupyterhub/jupyterhub:2.3
 
 # acl


### PR DESCRIPTION
In order to be able to try Sidestickies with ep_weave, I have added ep_weave related services as an optional Docker Compose file. And I also reorganized NBSearch's related services using OpenID Connect.


The configuration is as follows. (Also added at the end of the README)

----


docker-compose.*.yml files define the additional services for extensions.

- `docker-compose.nbsearch.yml` includes the services for NBSearch.
- `docker-compose.ep_weave.yml` includes the services for ep_weave.

You can start all services with the following command.

    $ sudo docker compose -f docker-compose.yml -f docker-compose.nbsearch.yml -f docker-compose.ep_weave.yml up -d

```mermaid
graph TD
    JupyterHub[JupyterHub] -- service --> Service[jupyterhub_oidcp]
    JupyterHub -- service --> SolrProxy[oauth2-proxy for Solr]
    JupyterHub -- service --> EPWeaveProxy[nginx for ep_weave]
    SolrProxy -- OpenID Connect --> Service
    ep_weave -- OpenID Connect --> Service
    JupyterHub -- spawn --> JupyterNotebook[single-user server]
    JupyterNotebook -- extension --> NBSearch[NBSearch]
    JupyterNotebook -- extension --> Sidestickies[Sidestickies]

    subgraph NBSearchGroup[docker-compose.nbsearch.yml]
        NBSearch --> SolrNBSearch[Solr for NBSearch]
        NBSearch -- S3 --> MinIO[MinIO for NBSearch]
        SolrProxy -- Reverse Proxy --> SolrNBSearch
    end

    subgraph EPWeaveGroup[docker-compose.ep_weave.yml]
        ep_weave[ep_weave] --> SolrEPWeave[Solr for ep_weave]
        ep_weave --> Postgres[PostgreSQL for ep_weave]
        EPWeaveProxy -- Reverse Proxy --> ep_weave
        Sidestickies -- API --> ep_weave
    end
```
