### PR TITLE
Specify the cookie name to allow multiple oauth2-proxy to be deployed

### DIFF
--- a/docker-compose.nbsearch.yml
+++ b/docker-compose.nbsearch.yml
@@ -38,6 +38,7 @@ services:
       - --client-id=${NBSEARCHDB_OAUTH_CLIENT_ID:-nbsearchdb_oauth_client_changeme}
       - --client-secret=${NBSEARCHDB_OAUTH_CLIENT_SECRET:-nbsearchdb_oauth_secret_changeme}
       - --cookie-secret=${NBSEARCHDB_COOKIE_SECRET:-nbsearchdb_cookiesecret_changeme}
+      - --cookie-name=_oauth2_proxy_nbsearchdb
       - --redirect-url=https://${SERVER_NAME}/services/solr/oauth2/callback
       - --oidc-issuer-url=http://jupyterhub:8000/services/oidcp/internal/
       - --email-domain=admin.jupyterhub


### PR DESCRIPTION
Since the cookie name has not been explicitly given to oauth2-proxy until now, there was a problem where the cookies would become confused when multiple oauth2-proxy instances were started in a single OperationHub.
There are no problems with the configuration currently published on GitHub, but the `--cookie-name` parameter has been added to make it clear that the `--cookie-name` setting is recommended.