### PR TITLE
Add nginx ACME module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,57 @@ Put TLS certificate and key files to the following path.
 
 If intermediate certificate file is requires, concatenate intermediate certificate and server certificate file.
 
+### Using nginx ACME module
+
+As an alternative to putting certificate files under `./cert`, you can use the
+nginx ACME module with `docker-compose.acme.yml`.
+
+Set the following variables in `.env`. Start with the Let's Encrypt staging
+directory.
+
+    SERVER_NAME=ophub.example.com
+    ACME_CONTACT=mailto:admin@ophub.example.com
+    ACME_DIRECTORY=https://acme-staging-v02.api.letsencrypt.org/directory
+    ACME_STATE_NAME=letsencrypt-staging
+
+After confirming that issuance works, switch to the production directory and
+use a separate state name.
+
+    ACME_DIRECTORY=https://acme-v02.api.letsencrypt.org/directory
+    ACME_STATE_NAME=letsencrypt-prod
+
+Start OperationHub with the ACME override.
+
+    $ sudo docker compose -f docker-compose.yml -f docker-compose.acme.yml build
+    $ sudo docker compose -f docker-compose.yml -f docker-compose.acme.yml up -d
+
+The ACME override publishes port 80 for HTTP-01 challenges in addition to the
+HTTPS port. `SERVER_NAME` must be a DNS name reachable from the ACME CA and
+must not include a port number.
+
+ACME account state is stored in `/var/lib/jupyterhub/acme`. It contains the
+ACME account key, certificates, and certificate private keys. Do not remove this
+directory unless you intend to discard the ACME account state.
+
+#### UPKI ACME
+
+UPKI ACME is supported by editing the commented UPKI lines in
+`docker-compose.acme.yml`. UPKI requires External Account Binding (EAB), so keep
+the EAB HMAC key in a root-readable file and mount it as shown in the compose
+file comments.
+
+Set the following variables in `.env`.
+
+    SERVER_NAME=ophub.example.ac.jp
+    ACME_CONTACT=mailto:admin@example.ac.jp
+    ACME_DIRECTORY=https://secomtrust-acme.com/acme/
+    ACME_STATE_NAME=upki-ophub-example-ac-jp
+    UPKI_ACME_EAB_KID=(KeyID issued by UPKI)
+    UPKI_ACME_EAB_HMAC_KEY_FILE=/var/lib/jupyterhub/secrets/upki-eab-hmac-key
+
+The EAB HMAC key file must contain the base64url HMAC key issued by UPKI. Back
+up `/var/lib/jupyterhub/acme` and avoid deleting it.
+
 ## Step 6: Setting JupyterHub administrator
 
 Before you start OperationHub, make an administrator user.

--- a/docker-compose.acme.yml
+++ b/docker-compose.acme.yml
@@ -1,0 +1,33 @@
+services:
+    proxy:
+        ports:
+            - "80:8080"
+        environment:
+            SERVER_NAME: "${SERVER_NAME:?Set SERVER_NAME to the public DNS name for OperationHub}"
+            ACME_CONTACT: "${ACME_CONTACT:?Set ACME_CONTACT, for example mailto:admin@example.ac.jp}"
+            ACME_DIRECTORY: "${ACME_DIRECTORY:?Set ACME_DIRECTORY to the ACME directory URL}"
+            ACME_STATE_NAME: "${ACME_STATE_NAME:?Set ACME_STATE_NAME to a stable per-account state directory name}"
+            ACME_ISSUER_NAME: "letsencrypt"
+            ACME_CERT_OPTIONS: ""
+            ACME_EXTERNAL_ACCOUNT_KEY_DIRECTIVE: ""
+            # For UPKI ACME, replace the ACME_ISSUER_NAME, ACME_CERT_OPTIONS,
+            # and ACME_EXTERNAL_ACCOUNT_KEY_DIRECTIVE lines above with the
+            # following values:
+            # ACME_ISSUER_NAME: "upki"
+            # ACME_CERT_OPTIONS: "key=rsa:2048"
+            # ACME_EXTERNAL_ACCOUNT_KEY_DIRECTIVE: "external_account_key ${UPKI_ACME_EAB_KID} /run/secrets/upki_eab_hmac_key;"
+        volumes: !override
+            - /etc/localtime:/etc/localtime:ro
+            - ./nginx/nginx-acme.conf.template:/etc/nginx/nginx.conf.template:ro
+            - /var/lib/jupyterhub/acme:/var/cache/nginx/acme
+            # For UPKI ACME, also mount the EAB HMAC key file:
+            # - ${UPKI_ACME_EAB_HMAC_KEY_FILE:?Set UPKI_ACME_EAB_HMAC_KEY_FILE to the base64url EAB HMAC key file issued by UPKI}:/run/secrets/upki_eab_hmac_key:ro
+        command: >
+          /bin/bash -c
+          "mkdir -p /var/cache/nginx/acme/${ACME_STATE_NAME:?Set ACME_STATE_NAME to a stable per-account state directory name} &&
+          chown -R nginx:nginx /var/cache/nginx/acme &&
+          envsubst '$$SERVER_NAME $$ACME_CONTACT $$ACME_DIRECTORY $$ACME_ISSUER_NAME $$ACME_STATE_NAME $$ACME_CERT_OPTIONS $$ACME_EXTERNAL_ACCOUNT_KEY_DIRECTIVE'
+          < /etc/nginx/nginx.conf.template
+          > /etc/nginx/nginx.conf &&
+          nginx -t &&
+          exec nginx -g 'daemon off;'"

--- a/nginx/nginx-acme.conf.template
+++ b/nginx/nginx-acme.conf.template
@@ -1,0 +1,79 @@
+load_module modules/ngx_http_acme_module.so;
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+    client_max_body_size 50M;
+
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    acme_issuer ${ACME_ISSUER_NAME} {
+        uri         ${ACME_DIRECTORY};
+        contact     ${ACME_CONTACT};
+        state_path  /var/cache/nginx/acme/${ACME_STATE_NAME};
+        ${ACME_EXTERNAL_ACCOUNT_KEY_DIRECTIVE}
+        accept_terms_of_service;
+    }
+
+    acme_shared_zone zone=ophub_acme:1M;
+
+    server {
+        listen 8080;
+        server_name ${SERVER_NAME};
+
+        location / {
+            return 404;
+        }
+    }
+
+    server {
+        listen 8443 ssl;
+        server_name ${SERVER_NAME};
+
+        acme_certificate ${ACME_ISSUER_NAME} ${ACME_CERT_OPTIONS};
+
+        ssl_certificate      $acme_certificate;
+        ssl_certificate_key  $acme_certificate_key;
+        ssl_certificate_cache max=2;
+
+        location / {
+            proxy_pass http://jupyterhub:8000;
+            proxy_redirect default;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_set_header Host $http_host;
+            proxy_set_header Origin $http_origin;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Scheme $scheme;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Referer $http_referer;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `docker-compose.acme.yml` override and `nginx/nginx-acme.conf.template` to issue and renew TLS certificates via the nginx ACME module, as an alternative to placing certificate files under `./cert`. Both Let's Encrypt and UPKI ACME (with External Account Binding) are supported.

## Note
- `nginx-acme.conf.template` replaces the whole `nginx.conf` instead of being a `conf.d` fragment because `load_module` is main-context only; HTTPS proxy behavior matches `nginx.conf.template`, only ACME-specific directives are added.