### PR TITLE
Update ep_weave to etherpad 3 based image

### DIFF
--- a/docker-compose.ep_weave.yml
+++ b/docker-compose.ep_weave.yml
@@ -31,8 +31,6 @@ services:
     build:
       context: ./images/ep_weave/ep_weave
       dockerfile: Dockerfile
-      args:
-        - ETHERPAD_IMAGE_TAG=develop
     environment:
       DB_HOST: ep-weave-postgresql
       DB_NAME: etherpad

--- a/images/ep_weave/settings/local.json
+++ b/images/ep_weave/settings/local.json
@@ -660,6 +660,9 @@
     "client_secret": "${EP_WEAVE_OAUTH_CLIENT_SECRET}",
     "base_url": "${EP_WEAVE_BASE_URL}"
   },
+  "ep_webrtc": {
+    "enabled": false
+  },
   "ep_weave": {
     "basePath": "/services/ep_weave"
   }


### PR DESCRIPTION
## Summary
- Update the `images/ep_weave/ep_weave` submodule to the latest upstream main, which builds on `etherpad/etherpad:3` and no longer runs `npm pack` during the image build. Recent etherpad images dropped npm in favor of pnpm, so the previous build had started failing with `npm: not found` (see the CI failure on #47).
- Remove the `ETHERPAD_IMAGE_TAG=develop` build arg override so the image tag follows the upstream Dockerfile default (`3`) instead of the floating `develop` tag.
- Disable the newly bundled `ep_webrtc` plugin in `local.json`, matching the upstream demo settings.

CI has been verified on my fork: https://github.com/yacchin1205/OperationHub/pull/1